### PR TITLE
Display kicks in channel buffers

### DIFF
--- a/app/src/main/java/io/mrarm/irc/util/MessageBuilder.java
+++ b/app/src/main/java/io/mrarm/irc/util/MessageBuilder.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import io.mrarm.chatlib.dto.ChannelModeMessageInfo;
 import io.mrarm.chatlib.dto.HostInfoMessageInfo;
+import io.mrarm.chatlib.dto.KickMessageInfo;
 import io.mrarm.chatlib.dto.MessageInfo;
 import io.mrarm.chatlib.dto.NickChangeMessageInfo;
 import io.mrarm.chatlib.dto.NickWithPrefix;
@@ -312,6 +313,13 @@ public class MessageBuilder {
                         SpannableStringHelper.getText(mContext,
                                 message.getMessage() == null ? R.string.message_part_no_message : R.string.message_part,
                                 buildColoredNick(senderNick), message.getMessage()));
+            case KICK:
+                String kickedNick = ((KickMessageInfo) message).getKickedNick();
+                return processFormat(mEventMessageFormat, message.getDate(), null,
+                        SpannableStringHelper.getText(mContext,
+                                R.string.message_kick, buildColoredNick(senderNick),
+                                buildColoredNick(kickedNick),
+                                message.getMessage()));
             case QUIT:
                 return processFormat(mEventMessageFormat, message.getDate(), null,
                         SpannableStringHelper.getText(mContext, R.string.message_quit, buildColoredNick(senderNick), message.getMessage()));

--- a/app/src/main/java/io/mrarm/irc/util/MessageBuilder.java
+++ b/app/src/main/java/io/mrarm/irc/util/MessageBuilder.java
@@ -313,13 +313,14 @@ public class MessageBuilder {
                         SpannableStringHelper.getText(mContext,
                                 message.getMessage() == null ? R.string.message_part_no_message : R.string.message_part,
                                 buildColoredNick(senderNick), message.getMessage()));
-            case KICK:
+            case KICK: {
                 String kickedNick = ((KickMessageInfo) message).getKickedNick();
                 return processFormat(mEventMessageFormat, message.getDate(), null,
                         SpannableStringHelper.getText(mContext,
                                 R.string.message_kick, buildColoredNick(senderNick),
                                 buildColoredNick(kickedNick),
                                 message.getMessage()));
+            }
             case QUIT:
                 return processFormat(mEventMessageFormat, message.getDate(), null,
                         SpannableStringHelper.getText(mContext, R.string.message_quit, buildColoredNick(senderNick), message.getMessage()));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="message_hint">Send a message</string>
     <string name="message_disconnected">Disconnected</string>
     <string name="message_join">%s has joined</string>
+    <string name="message_kick">%s has kicked %s: %s</string>
     <string name="message_part">%s has left (%s)</string>
     <string name="message_part_no_message">%s has left</string>
     <string name="message_quit">%s has disconnected (%s)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="message_hint">Send a message</string>
     <string name="message_disconnected">Disconnected</string>
     <string name="message_join">%s has joined</string>
-    <string name="message_kick">%s has kicked %s: %s</string>
+    <string name="message_kick">%s has kicked %s (%s)</string>
     <string name="message_part">%s has left (%s)</string>
     <string name="message_part_no_message">%s has left</string>
     <string name="message_quit">%s has disconnected (%s)</string>


### PR DESCRIPTION
This PR fixes desyncs caused by missing kick handling, as mentioned in https://github.com/MCMrARM/revolution-irc/issues/108#issuecomment-386821295

This depends on two PRs sent to chatlib and chatlib-android-storage:
- https://github.com/MCMrARM/chatlib/pull/2
- https://github.com/MCMrARM/chatlib-android-storage/pull/1