### PR TITLE
Gets the context that contains view on onClick() without the wrapper of android.support.v7.widget.TintContextWrapper

### DIFF
--- a/app/src/main/java/io/mrarm/irc/util/LinkHelper.java
+++ b/app/src/main/java/io/mrarm/irc/util/LinkHelper.java
@@ -47,7 +47,7 @@ public class LinkHelper {
 
         @Override
         public void onClick(View view) {
-            MainActivity activity = ((MainActivity) view.getContext());
+            MainActivity activity = ((MainActivity) view.getRootView().getContext());
             MenuBottomSheetDialog dialog = new MenuBottomSheetDialog(view.getContext());
             dialog.addHeader(mChannel);
             dialog.addItem(R.string.action_open, R.drawable.ic_open_in_new, (MenuBottomSheetDialog.Item item) -> {


### PR DESCRIPTION
Fix for https://github.com/MCMrARM/revolution-irc/issues/161
Tested it on an emulator with KitKat 4.4 (api 19) and Lollipop 5.0.1 (api 21) and it worked fine on both, the dialog was displayed correctly on KitKat, and doesn't seem to introduce any regressions on Lollipop.