### PR TITLE
Fix an assortment of typos

### DIFF
--- a/app/src/main/java/io/mrarm/irc/DCCManager.java
+++ b/app/src/main/java/io/mrarm/irc/DCCManager.java
@@ -575,7 +575,7 @@ public class DCCManager implements DCCServerManager.UploadListener, DCCClient.Cl
             ServerConnectionInfo connection = ServerConnectionManager.getInstance(mContext)
                     .getConnection(mServerUUID);
             if (connection == null)
-                throw new IOException("The connection doesn't exit");
+                throw new IOException("The connection doesn't exist");
             FileChannel file;
             String downloadFileName = getUnescapedFileName().replace('/', '_');
             String ext = getFileExtension();

--- a/app/src/main/java/io/mrarm/irc/ServerConnectionInfo.java
+++ b/app/src/main/java/io/mrarm/irc/ServerConnectionInfo.java
@@ -277,7 +277,7 @@ public class ServerConnectionInfo {
                 && !hasWifi))
             return;
         if (helper.shouldReconnectOnConnectivityChange()) {
-            connect(); // this will be ignored if we are already corrected
+            connect(); // this will be ignored if we are already connected
         } else if (mReconnectQueueTime != -1L) {
             long reconnectDelay = mManager.getReconnectDelay(mCurrentReconnectAttempt++);
             if (reconnectDelay == -1)

--- a/app/src/main/java/io/mrarm/irc/chat/ChatMessagesAdapter.java
+++ b/app/src/main/java/io/mrarm/irc/chat/ChatMessagesAdapter.java
@@ -30,7 +30,7 @@ public class ChatMessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
     private ChatMessagesFragment mFragment;
     private List<MessageInfo> mMessages;
-    private LongPressSelectTouchListener mMutliSelectListener;
+    private LongPressSelectTouchListener mMultiSelectListener;
     private ChatSelectTouchListener mSelectListener;
     private Set<Integer> mSelectedItems = new TreeSet<>();
     private Drawable mItemBackground;
@@ -78,7 +78,7 @@ public class ChatMessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     }
 
     public void setMultiSelectListener(LongPressSelectTouchListener selectListener) {
-        mMutliSelectListener = selectListener;
+        mMultiSelectListener = selectListener;
         if (selectListener != null)
             selectListener.setListener(this);
     }
@@ -175,7 +175,7 @@ public class ChatMessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                 if (mSelectListener != null && mSelectedItems.size() == 0) {
                     mSelectListener.startLongPressSelect();
                 } else {
-                    mMutliSelectListener.startSelectMode(getAdapterPosition());
+                    mMultiSelectListener.startSelectMode(getAdapterPosition());
                 }
                 return true;
             });
@@ -213,9 +213,9 @@ public class ChatMessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             if (mFontSize != -1)
                 mText.setTextSize(TypedValue.COMPLEX_UNIT_SP, mFontSize);
 
-            if (mMutliSelectListener != null)
+            if (mMultiSelectListener != null)
                 setSelected(mSelectedItems.contains(position) ||
-                        mMutliSelectListener.isElementHightlighted(position), false);
+                        mMultiSelectListener.isElementHightlighted(position), false);
 
             if (NotificationManager.getInstance().shouldMessageUseMentionFormatting(mFragment.getConnectionInfo(), mFragment.getChannelName(), message))
                 mText.setText(AlignToPointSpan.apply(mText, MessageBuilder.getInstance(mText.getContext()).buildMessageWithMention(message)));

--- a/app/src/main/java/io/mrarm/irc/dialog/UserBottomSheetDialog.java
+++ b/app/src/main/java/io/mrarm/irc/dialog/UserBottomSheetDialog.java
@@ -219,7 +219,7 @@ public class UserBottomSheetDialog {
                 mTitle = itemView.findViewById(R.id.title);
                 mValue = itemView.findViewById(R.id.value);
                 itemView.setOnLongClickListener((View v) -> {
-                    copyValueToClipbord(v.getContext(), mTitle.getText(), mValue.getText());
+                    copyValueToClipboard(v.getContext(), mTitle.getText(), mValue.getText());
                     return true;
                 });
             }
@@ -342,7 +342,7 @@ public class UserBottomSheetDialog {
 
     }
 
-    private static void copyValueToClipbord(Context context, CharSequence key, CharSequence value) {
+    private static void copyValueToClipboard(Context context, CharSequence key, CharSequence value) {
         ClipboardManager clipboard = (ClipboardManager) context
                 .getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText(key, value);
@@ -353,7 +353,7 @@ public class UserBottomSheetDialog {
 
     private static View.OnLongClickListener createLongClickListener(Context context, int resId) {
         return (View v) -> {
-            copyValueToClipbord(context, context.getString(resId), ((TextView) v).getText());
+            copyValueToClipboard(context, context.getString(resId), ((TextView) v).getText());
             return true;
         };
     }

--- a/app/src/main/java/io/mrarm/irc/setting/fragment/InterfaceSettingsFragment.java
+++ b/app/src/main/java/io/mrarm/irc/setting/fragment/InterfaceSettingsFragment.java
@@ -92,8 +92,8 @@ public class InterfaceSettingsFragment extends SettingsListFragment
                 getResources().getStringArray(R.array.pref_entry_values_chat_history_swipe_mode),
                 SettingsHelper.SWIPE_LEFT_TO_RIGHT)
                 .linkPreference(prefs, SettingsHelper.PREF_CHAT_SEND_BOX_HISTORY_SWIPE_MODE));
-        a.add(new CheckBoxSetting(getString(R.string.pref_title_chat_mutli_scroll_mode),
-                getString(R.string.pref_summary_chat_mutli_scroll_mode), false)
+        a.add(new CheckBoxSetting(getString(R.string.pref_title_chat_multi_scroll_mode),
+                getString(R.string.pref_summary_chat_multi_scroll_mode), false)
                 .linkPreference(prefs, SettingsHelper.PREF_CHAT_MULTI_SELECT_MODE));
         a.add(new CheckBoxSetting(getString(R.string.pref_title_chat_show_dcc_send),
                 getString(R.string.pref_summary_chat_show_dcc_send), false)

--- a/app/src/main/java/io/mrarm/irc/util/ColorFilterWorkaroundDrawable.java
+++ b/app/src/main/java/io/mrarm/irc/util/ColorFilterWorkaroundDrawable.java
@@ -17,7 +17,7 @@ import android.support.annotation.Nullable;
  * This workarounds this bug by creating a new drawable when setting a color filter, and restoring
  * the original one when clearing the color filter.
  *
- * [1] https://github.com/androi/platform_frameworks_base/blob/4a81674b45b7250c4e2a80330371f7aa1c066d05/graphics/java/android/graphics/drawable/DrawableContainer.java#L173
+ * [1] https://github.com/android/platform_frameworks_base/blob/4a81674b45b7250c4e2a80330371f7aa1c066d05/graphics/java/android/graphics/drawable/DrawableContainer.java#L173
  * [2] https://github.com/android/platform_frameworks_base/blob/4a81674b45b7250c4e2a80330371f7aa1c066d05/graphics/java/android/graphics/drawable/DrawableContainer.java#L538
  *     https://github.com/android/platform_frameworks_base/blob/4a81674b45b7250c4e2a80330371f7aa1c066d05/graphics/java/android/graphics/drawable/DrawableContainer.java#L543
  */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,7 +128,7 @@
         <item quantity="other">connecting to %d networks</item>
     </plurals>
     <plurals name="service_status_disconnected">
-        <item quantity="one">disconnected fom %d network</item>
+        <item quantity="one">disconnected from %d network</item>
         <item quantity="other">disconnected from %d networks</item>
     </plurals>
     <plurals name="notify_multiple_messages">
@@ -179,7 +179,7 @@
     <string name="server_port">Port</string>
     <string name="server_ssl">Use SSL</string>
     <plurals name="server_manage_custom_certs_text">
-        <item quantity="one">%d custom certificates saved</item>
+        <item quantity="one">%d custom certificate saved</item>
         <item quantity="other">%d custom certificates saved</item>
     </plurals>
     <string name="server_manage_custom_certs">Manage custom certificates</string>
@@ -610,7 +610,10 @@
     <string name="title_activity_dcc">DCC transfers</string>
     <string name="notification_channel_dcc">@string/title_activity_dcc</string>
     <string name="dcc_summary_notification_title">DCC transfers in progress</string>
-    <string name="dcc_summary_notification_text">%d transfers in progress</string>
+    <plurals name="dcc_summary_notification_text">
+        <item quantity="one">%d transfer in progress</item>
+        <item quantity="other">%d transfers in progress</item>
+    </plurals>
     <string name="dcc_active_upload_transfer_status">Uploading to %s</string>
     <string name="dcc_active_download_transfer_status">Downloading from %s</string>
     <string name="dcc_active_waiting_for_connection">Waiting for connection…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,8 +302,8 @@
     <string name="pref_title_chat_box_always_multiline">Multiline send text box</string>
     <string name="pref_summary_chat_box_always_multiline">Enables word-wrap in the text box and replaces the send button with an enter in the IME.</string>
     <string name="pref_title_chat_box_history_swipe_mode">History swipe-based navigation mode</string>
-    <string name="pref_title_chat_mutli_scroll_mode">Use a batch message selection mode</string>
-    <string name="pref_summary_chat_mutli_scroll_mode">Always enables the old batch message selection mode</string>
+    <string name="pref_title_chat_multi_scroll_mode">Use a batch message selection mode</string>
+    <string name="pref_summary_chat_multi_scroll_mode">Always enables the old batch message selection mode</string>
     <string name="pref_title_chat_show_dcc_send">Show DCC send button</string>
     <string name="pref_summary_chat_show_dcc_send">Show a button to send a file using DCC in private chats</string>
 


### PR DESCRIPTION
I'd been looking at ["disconnected fom 1 network"](https://github.com/MCMrARM/revolution-irc/blob/b8ccb76e2bdc1be9487a311211c95ee9432df026/app/src/main/res/values/strings.xml#L131) for some months now, and had finally got around to looking at the code. When I found another typo right away, it seemed like a good idea to look for more. This is what a quick glance through every source file came up with.

My English is good, Java not so much; nitpicks are welcome. Specifically, I'm not sure if changing string names (in this case `pref_title_chat_mutli_scroll_mode`) will break anything.