### PR TITLE
pickeduname v5 patch - no version setting

### DIFF
--- a/app/src/main/java/io/mrarm/irc/EditIgnoreEntryActivity.java
+++ b/app/src/main/java/io/mrarm/irc/EditIgnoreEntryActivity.java
@@ -11,6 +11,7 @@ import android.widget.Toast;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.regex.PatternSyntaxException;
 
 import io.mrarm.irc.config.ServerConfigData;
 import io.mrarm.irc.config.ServerConfigManager;
@@ -25,6 +26,7 @@ public class EditIgnoreEntryActivity extends ThemedActivity {
     private EditText mNick;
     private EditText mUser;
     private EditText mHost;
+    private EditText mMesg;
     private EditText mComment;
     private CheckBox mChannelMessages;
     private CheckBox mChannelNotices;
@@ -45,6 +47,7 @@ public class EditIgnoreEntryActivity extends ThemedActivity {
         mNick = findViewById(R.id.nick);
         mUser = findViewById(R.id.user);
         mHost = findViewById(R.id.host);
+        mMesg = findViewById(R.id.mesg);
         mComment = findViewById(R.id.comment);
 
         mChannelMessages = findViewById(R.id.channel_messages);
@@ -56,6 +59,7 @@ public class EditIgnoreEntryActivity extends ThemedActivity {
             mNick.setText(mEntry.nick);
             mUser.setText(mEntry.user);
             mHost.setText(mEntry.host);
+            mMesg.setText(mEntry.mesg);
             mComment.setText(mEntry.comment);
             mChannelMessages.setChecked(mEntry.matchChannelMessages);
             mChannelNotices.setChecked(mEntry.matchChannelNotices);
@@ -76,12 +80,17 @@ public class EditIgnoreEntryActivity extends ThemedActivity {
         mEntry.nick = mNick.getText().length() > 0 ? mNick.getText().toString() : null;
         mEntry.user = mUser.getText().length() > 0 ? mUser.getText().toString() : null;
         mEntry.host = mHost.getText().length() > 0 ? mHost.getText().toString() : null;
+        mEntry.mesg = mMesg.getText().length() > 0 ? mMesg.getText().toString() : null;
         mEntry.comment = mComment.getText().length() > 0 ? mComment.getText().toString() : null;
         mEntry.matchChannelMessages = mChannelMessages.isChecked();
         mEntry.matchChannelNotices = mChannelNotices.isChecked();
         mEntry.matchDirectMessages = mDirectMessages.isChecked();
         mEntry.matchDirectNotices = mDirectNotices.isChecked();
-        mEntry.updateRegexes();
+        try {
+            mEntry.updatePatterns();
+        } catch (PatternSyntaxException e) {
+            Toast.makeText(this, this.getResources().getString(R.string.notification_regex_pattern_error, e.getPattern(), e.getMessage()), Toast.LENGTH_LONG).show();
+        }
         try {
             ServerConfigManager.getInstance(this).saveServer(mServer);
         } catch (IOException e) {

--- a/app/src/main/java/io/mrarm/irc/EditServerActivity.java
+++ b/app/src/main/java/io/mrarm/irc/EditServerActivity.java
@@ -85,6 +85,7 @@ public class EditServerActivity extends ThemedActivity {
     private EditText mServerPort;
     private TextInputLayout mServerPortCtr;
     private CheckBox mServerSSL;
+    private CheckBox mServerCtcpVersion;
     private View mServerSSLCertsButton;
     private TextView mServerSSLCertsLbl;
     private ResettablePasswordHelper mServerPass;
@@ -146,6 +147,7 @@ public class EditServerActivity extends ThemedActivity {
         mServerPort = findViewById(R.id.server_address_port);
         mServerPortCtr = findViewById(R.id.server_address_port_ctr);
         mServerSSL = findViewById(R.id.server_ssl_checkbox);
+        mServerCtcpVersion = findViewById(R.id.server_ctcp_mode_checkbox);
         mServerSSLCertsButton = findViewById(R.id.server_ssl_certs);
         mServerSSLCertsLbl = findViewById(R.id.server_ssl_cert_lbl);
         mServerPass = new ResettablePasswordHelper(
@@ -248,6 +250,7 @@ public class EditServerActivity extends ThemedActivity {
             mServerName.setText(mEditServer.name);
             mServerAddress.setText(mEditServer.address);
             mServerSSL.setChecked(mEditServer.ssl);
+            mServerCtcpVersion.setChecked(mEditServer.censeCtcpVersion);
             mServerPort.setText(String.valueOf(mEditServer.port));
             mServerRejoinChannels.setChecked(mEditServer.rejoinChannels);
 
@@ -384,6 +387,7 @@ public class EditServerActivity extends ThemedActivity {
         mEditServer.address = mServerAddress.getText().toString();
         mEditServer.port = Integer.parseInt(mServerPort.getText().toString());
         mEditServer.ssl = mServerSSL.isChecked();
+        mEditServer.censeCtcpVersion = mServerCtcpVersion.isChecked();
         mEditServer.nicks = Arrays.asList(mServerNick.getItems());
         if (mEditServer.nicks.size() == 0)
             mEditServer.nicks = null;

--- a/app/src/main/java/io/mrarm/irc/IgnoreListAdapter.java
+++ b/app/src/main/java/io/mrarm/irc/IgnoreListAdapter.java
@@ -4,7 +4,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.graphics.Typeface;
+import android.graphics.fonts.Font;
+import android.text.style.CharacterStyle;
 import android.text.style.ForegroundColorSpan;
+import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,6 +18,7 @@ import android.widget.Toast;
 
 import java.io.IOException;
 
+import io.mrarm.arsc.chunks.ResValue;
 import io.mrarm.irc.config.ServerConfigData;
 import io.mrarm.irc.config.ServerConfigManager;
 import io.mrarm.irc.dialog.MenuBottomSheetDialog;
@@ -94,6 +100,10 @@ public class IgnoreListAdapter extends RecyclerView.Adapter<IgnoreListAdapter.It
 
         public void bind(ServerConfigData.IgnoreEntry entry) {
             ColoredTextBuilder builder = new ColoredTextBuilder();
+            if (entry.isBad)
+               builder.append(mText.getContext().getString(R.string.notifcation_ignore_list_adapter_badre_marker),
+                       new ForegroundColorSpan(Color.RED), new StyleSpan(Typeface.BOLD));
+
             if (entry.nick == null || entry.nick.equals("*"))
                 builder.append("*", new ForegroundColorSpan(mTextColorSecondary));
             else
@@ -111,10 +121,17 @@ public class IgnoreListAdapter extends RecyclerView.Adapter<IgnoreListAdapter.It
             else
                 builder.append(entry.host, new ForegroundColorSpan(mTextColorHost));
 
+            if (entry.mesg != null) {
+                if (builder.getSpannable().length() != 0)
+                    builder.append(" " );
+                builder.append(entry.mesg);
+            }
+
             if (entry.comment != null) {
                 builder.append(" ");
                 builder.append(entry.comment, new ForegroundColorSpan(mTextColorSecondary));
             }
+
             mText.setText(builder.getSpannable());
         }
 

--- a/app/src/main/java/io/mrarm/irc/ServerConnectionInfo.java
+++ b/app/src/main/java/io/mrarm/irc/ServerConnectionInfo.java
@@ -1,8 +1,10 @@
 package io.mrarm.irc;
 
+import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -129,12 +131,29 @@ public class ServerConnectionInfo {
             DCCManager dccManager = DCCManager.getInstance(getConnectionManager().getContext());
             messageHandler.setDCCServerManager(dccManager.getServer());
             messageHandler.setDCCClientManager(dccManager.createClient(this));
-            messageHandler.setCtcpVersionReply(mManager.getContext()
-                    .getString(R.string.app_name), BuildConfig.VERSION_NAME, "Android");
+            {
+                String appname;
+                String appver;
+
+                if (mServerConfig.censeCtcpVersion) {
+                    appname = "IRC client";
+                    appver = "default";
+                } else {
+                    appname = mManager.getContext().getString(R.string.app_name);
+                    appver = BuildConfig.VERSION_NAME;
+                }
+                messageHandler.setCtcpVersionReply(appname, appver, "Android");
+            }
             connection.addDisconnectListener((IRCConnection conn, Exception reason) -> {
                 notifyDisconnected();
             });
             createdNewConnection = true;
+            if (ServerConfigData.checkCompileIgnoreListEntries(mServerConfig) != 0) {
+                Context ctx = this.getConnectionManager().getContext();
+                String errstr = ctx.getString(R.string.notification_server_connection_regexp_badcount, mServerConfig.badCount);
+                Toast.makeText(ctx, errstr, Toast.LENGTH_LONG).show();
+                Log.d("ServerConnectionInfo", errstr);
+            }
         } else {
             connection = (IRCConnection) mApi;
         }

--- a/app/src/main/java/io/mrarm/irc/util/IgnoreListMessageFilter.java
+++ b/app/src/main/java/io/mrarm/irc/util/IgnoreListMessageFilter.java
@@ -2,6 +2,8 @@ package io.mrarm.irc.util;
 
 import android.util.Log;
 
+import java.util.regex.PatternSyntaxException;
+
 import io.mrarm.chatlib.dto.MessageInfo;
 import io.mrarm.chatlib.irc.MessageFilter;
 import io.mrarm.chatlib.irc.ServerConnectionData;
@@ -19,15 +21,15 @@ public class IgnoreListMessageFilter implements MessageFilter {
     public boolean filter(ServerConnectionData serverConnectionData, String channel, MessageInfo message) {
         if (mConfig.ignoreList != null && message.getSender() != null) {
             for (ServerConfigData.IgnoreEntry entry : mConfig.ignoreList) {
-                if (entry.nick == null && entry.user == null && entry.host == null)
+                if (entry.isBad || ((entry.nick == null && entry.user == null && entry.host == null && entry.mesg == null)))
                     continue;
-                if (entry.nickRegex == null && entry.userRegex == null && entry.hostRegex == null)
-                    entry.updateRegexes();
                 if (entry.nickRegex != null && !entry.nickRegex.matcher(message.getSender().getNick()).matches())
                     continue;
                 if (entry.userRegex != null && (message.getSender().getUser() == null || !entry.userRegex.matcher(message.getSender().getUser()).matches()))
                     continue;
                 if (entry.hostRegex != null && (message.getSender().getHost() == null || !entry.hostRegex.matcher(message.getSender().getHost()).matches()))
+                    continue;
+                if (entry.mesgRegex != null && (message.getMessage() == null || !entry.mesgRegex.matcher(message.getMessage()).matches()))
                     continue;
                 Log.d("IgnoreListMessageFilter", "Ignore message: " + message.getSender().getNick() + " " + message.getMessage());
                 return false;

--- a/app/src/main/java/io/mrarm/irc/util/SimpleWildcardPattern.java
+++ b/app/src/main/java/io/mrarm/irc/util/SimpleWildcardPattern.java
@@ -1,10 +1,11 @@
 package io.mrarm.irc.util;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public class SimpleWildcardPattern {
 
-    public static Pattern compile(String str) {
+    private static String parseGlob(String str) {
         if (str == null)
             return null;
         StringBuilder ret = new StringBuilder();
@@ -25,7 +26,18 @@ public class SimpleWildcardPattern {
         if (str.length() > pi)
             ret.append(Pattern.quote(str.substring(pi)));
         ret.append('$');
-        return Pattern.compile(ret.toString());
+        return ret.toString();
     }
 
+    private static String strGlobRe(String str) {
+        if (str.startsWith("/") && str.endsWith("/"))
+            return str.substring(1, str.length() - 1);
+        if (str.startsWith("?") && str.endsWith("?"))
+            return parseGlob(str.substring(1, str.length() - 1));
+        return parseGlob(str);
+    }
+
+    public static Pattern pattCompile(String str) throws PatternSyntaxException {
+        return Pattern.compile(strGlobRe(str));
+    }
 }

--- a/app/src/main/res/layout/activity_edit_ignore_entry.xml
+++ b/app/src/main/res/layout/activity_edit_ignore_entry.xml
@@ -23,7 +23,7 @@
                 android:id="@+id/nick"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/value_any" />
+                android:hint="@string/value_any_re_glob" />
 
         </io.mrarm.irc.view.LabelLayout>
 
@@ -42,7 +42,7 @@
                 android:id="@+id/user"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/value_any" />
+                android:hint="@string/value_any_re_glob" />
 
         </io.mrarm.irc.view.LabelLayout>
 
@@ -61,7 +61,7 @@
                 android:id="@+id/host"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/value_any" />
+                android:hint="@string/value_any_re_glob" />
 
         </io.mrarm.irc.view.LabelLayout>
 
@@ -69,7 +69,7 @@
             android:id="@+id/channel_messages"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/host_ctr"
+            android:layout_below="@+id/mesg_ctr"
             android:layout_marginTop="@dimen/edit_command_alias_spacing"
             android:layout_marginLeft="@dimen/activity_horizontal_margin_s4"
             android:layout_marginRight="@dimen/activity_horizontal_margin_s4"
@@ -105,6 +105,24 @@
             android:layout_marginRight="@dimen/activity_horizontal_margin_s4"
             android:text="@string/notification_rule_notice"
             android:checked="true" />
+
+        <io.mrarm.irc.view.LabelLayout
+            android:id="@+id/mesg_ctr"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/host_ctr"
+            android:layout_marginLeft="@dimen/activity_horizontal_margin_s4"
+            android:layout_marginTop="@dimen/edit_command_alias_spacing"
+            android:layout_marginRight="@dimen/activity_horizontal_margin_s4"
+            android:hint="@string/mesg_match"
+            app:doNotExpand="true">
+
+            <EditText
+                android:id="@+id/mesg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/value_any_re_glob" />
+        </io.mrarm.irc.view.LabelLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/comment_ctr"

--- a/app/src/main/res/layout/activity_edit_server.xml
+++ b/app/src/main/res/layout/activity_edit_server.xml
@@ -95,12 +95,19 @@
                 android:layout_height="wrap_content"
                 android:layout_toRightOf="@id/server_ssl_icon"
                 android:layout_toEndOf="@id/server_ssl_icon"
-                android:layout_centerVertical="true"
                 android:text="@string/server_ssl"
                 android:checked="true" />
 
-        </RelativeLayout>
+            <CheckBox
+                android:id="@+id/server_ctcp_mode_checkbox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_toRightOf="@id/server_ssl_icon"
+                android:layout_below="@id/server_ssl_checkbox"
+                android:text="@string/server_ctcp_version_mode"
+                android:checked="false" />
 
+        </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/server_ssl_certs"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,7 @@
     <string name="server_manage_custom_certs">Manage custom certificates</string>
     <string name="server_password_unchanged">Unchanged</string>
     <string name="server_authentication_mode">Authentication mode</string>
+    <string name="server_ctcp_version_mode">Restrict CTCP VERSION</string>
     <string name="server_channels">Auto-join channels</string>
     <string name="server_rejoin_channels">Rejoin opened channels</string>
     <string name="server_commands">Auto-run commands</string>
@@ -259,6 +260,7 @@
     <string name="value_custom_specific">Custom (%s)</string>
     <string name="value_none">None</string>
     <string name="value_any">Any</string>
+    <string name="value_any_re_glob">Any ?glob? or /re/</string>
     <string name="value_always">Always</string>
     <string name="value_never">Never</string>
     <string name="value_preset">Preset</string>
@@ -474,7 +476,11 @@
     <string name="notification_tip_no_custom_rules">There are no custom rules. You can add one with the plus button in the bottom right corner.</string>
     <string name="notification_custom_rule_deleted">Notification rule deleted.</string>
     <string name="notification_rule_name_collision">A notification rule with this name already exists</string>
-    <string name="notification_rule_regex_invalid">Invalid Regex</string>
+
+    <string name="notification_rule_regex_invalid">Invalid regexp</string>
+    <string name="notification_server_connection_regexp_badcount">Regexp pattern errors: %d.\nPlease edit the Ignore List</string>
+    <string name="notifcation_ignore_list_adapter_badre_marker">Bad:</string>
+    <string name="notification_regex_pattern_error">Regexp pattern error in:\n%s\n%s</string>
 
     <string name="notification_rule_nick">Nick mentions</string>
     <string name="notification_rule_chan_messages">Channel messages</string>
@@ -662,6 +668,10 @@
     <string name="user_away">Away message</string>
 
     <string name="user_info_copied">Copied %s to clipboard.</string>
+
+    <!-- Ignore message text -->
+
+    <string name="mesg_match">Message text</string>
 
     <!-- Color picker -->
 


### PR DESCRIPTION
@MCMrARM I pushed v5 patch with most of your suggestions implemented, with no version code or README.md edits in the push.

I had to wipe the v4 repo, this  is a new one, so nothing to revert on v4, just forget it. Some notes, addressing your comments in #296 #297 etc.:

1. `isBad` is now an int, as are all former Integers I used. `isBad` is not transient and is saved to exported zip settings backup, this is useful, it allows people like me to edit the re's in the zip file, seeing better which one is bad.
2. Every string is now in `strings.xml`. Pluralization was handled using the `Objects:` syntax which is suggested acceptable by Android documentation on pluralization. Ellipsization was present in the form you mentioned in comments, in the ui `.xml` file, and is not changed by me, so I removed my unsightly ellipsization in the Java code.
3. The code around `compilePattern()` etc. is redone as you suggested, losing my C-ish code. I refactored a bit and moved the pattern checker into `config/ServerConfigData.java`.
4. Code _quality_ issues were addressed everywhere, I hope. I checked twice so far.

The code in the patch is known to build a working debug APK, tested on one device so far, with the added new features.

The patch does not add any warnings to the build process, the build had 100 warnings before patching, and still has as many. None are in sections I added or patched, that I can see.
